### PR TITLE
Migrate AuthDomain from monolith into auth-service

### DIFF
--- a/backend-microservices/auth-service/auth-service/pom.xml
+++ b/backend-microservices/auth-service/auth-service/pom.xml
@@ -48,12 +48,38 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/JwtAuthenticationFilter.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/JwtAuthenticationFilter.java
@@ -1,0 +1,95 @@
+package com.murat.orion.auth_service.AuthDomain.Config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import com.murat.orion.auth_service.AuthDomain.Entity.User;
+import com.murat.orion.auth_service.AuthDomain.Repository.UserRepository;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+
+
+        System.out.println("LOG 1: Filtre çalıştı. Header: " + authHeader);
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            System.out.println("LOG 2: Header yok veya Bearer değil. Anonim devam ediliyor.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String jwt = authHeader.substring(7);
+
+        try {
+            boolean isTokenValidInitial = jwtService.validateToken(jwt);
+            System.out.println("LOG 3: jwtService.validateToken sonucu: " + isTokenValidInitial);
+
+            if (!isTokenValidInitial) {
+                System.out.println("LOG 4: Token validasyonu başarısız oldu! Anonim devam ediliyor.");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            final String userEmail = jwtService.extractUsername(jwt);
+            System.out.println("LOG 5: Email çıkarıldı: " + userEmail);
+
+            if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                User user = userRepository.findByEmail(userEmail).orElse(null);
+
+                if (user != null) {
+                    System.out.println("LOG 6: User DB'den bulundu: " + user.getEmail());
+
+                    if (jwtService.isTokenValid(jwt, user)) {
+                        List<SimpleGrantedAuthority> authorities = List.of(
+                                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+                        );
+
+                        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                                user,
+                                null,
+                                authorities
+                        );
+
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+                        System.out.println("LOG 7: BAŞARILI! SecurityContext set edildi. Yetkiler: " + authorities);
+                    } else {
+                        System.out.println("LOG 7-HATA: isTokenValid(jwt, user) false döndü.");
+                    }
+                } else {
+                    System.out.println("LOG 6-HATA: User DB'de bulunamadı.");
+                }
+            }
+        } catch (Exception e) {
+            System.out.println("LOG EXCEPTION: " + e.getMessage());
+            logger.error("JWT Authentication failed: " + e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/JwtService.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/JwtService.java
@@ -1,0 +1,100 @@
+package com.murat.orion.auth_service.AuthDomain.Config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import com.murat.orion.auth_service.AuthDomain.Entity.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret:mySecretKey12345678901234567890123456789012}")
+    private String secretKey;
+
+    @Value("${jwt.expiration:3600000}")
+    private long jwtExpiration;
+
+    @Value("${jwt.refresh-expiration:604800000}")
+    private long refreshExpiration;
+
+    public String generateToken(User user) {
+        return buildToken(new HashMap<>(), user, jwtExpiration);
+    }
+
+    public String generateRefreshToken(User user) {
+        return buildToken(new HashMap<>(), user, refreshExpiration);
+    }
+
+    private String buildToken(Map<String, Object> extraClaims, User user, long expiration) {
+        return Jwts.builder()
+                .claims(extraClaims)
+                .subject(user.getEmail())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSignInKey())
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSignInKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public boolean isTokenValid(String token, User user) {
+        final String username = extractUsername(token);
+        return (username.equals(user.getEmail())) && !isTokenExpired(token);
+    }
+
+    public boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            extractAllClaims(token);
+            return !isTokenExpired(token);
+        } catch (ExpiredJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public long getExpirationTime() {
+        return jwtExpiration;
+    }
+
+    public long getRefreshExpirationTime() {
+        return refreshExpiration;
+    }
+
+    private SecretKey getSignInKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/OpenApiConfig.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/OpenApiConfig.java
@@ -1,0 +1,37 @@
+package com.murat.orion.auth_service.AuthDomain.Config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Orion API")
+                        .version("1.0")
+                        .description("Orion Banking Application API Documentation")
+                        .contact(new Contact()
+                                .name("Murat")
+                                .email("murat@orion.com")))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("JWT token girin. Örnek: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")));
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/SecurityConfig.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.murat.orion.auth_service.AuthDomain.Config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/invest/**").authenticated()
+                        .requestMatchers("/api/accounts/**").authenticated()
+                        .requestMatchers("/api/payments/**").authenticated()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Controller/AuthController.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Controller/AuthController.java
@@ -1,0 +1,64 @@
+package com.murat.orion.auth_service.AuthDomain.Controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.EmailLoginRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.RefreshTokenRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.RegisterRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.SendOtpRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.VerifyOtpRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.LoginResponse;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.OtpResponse;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.RefreshTokenResponse;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.RegisterResponse;
+import com.murat.orion.auth_service.AuthDomain.Service.AuthService;
+import com.murat.orion.auth_service.AuthDomain.Service.EmailLoginStrategy;
+import com.murat.orion.auth_service.AuthDomain.Service.SmsLoginStrategy;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final EmailLoginStrategy emailLoginStrategy;
+    private final SmsLoginStrategy smsLoginStrategy;
+
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+        RegisterResponse response = authService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+
+    @PostMapping("/login/email")
+    public ResponseEntity<LoginResponse> loginWithEmail(@Valid @RequestBody EmailLoginRequest request) {
+        LoginResponse response = emailLoginStrategy.login(request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @PostMapping("/login/sms/send-otp")
+    public ResponseEntity<OtpResponse> sendOtp(@Valid @RequestBody SendOtpRequest request) {
+        OtpResponse response = smsLoginStrategy.sendOtp(request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @PostMapping("/login/sms/verify")
+    public ResponseEntity<LoginResponse> verifyOtpAndLogin(@Valid @RequestBody VerifyOtpRequest request) {
+        LoginResponse response = smsLoginStrategy.verifyOtpAndLogin(request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<RefreshTokenResponse> refreshToken(@Valid @RequestBody RefreshTokenRequest request) {
+        RefreshTokenResponse response = authService.refreshToken(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/EmailLoginRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/EmailLoginRequest.java
@@ -1,0 +1,27 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailLoginRequest {
+
+    /**
+     * Kullanıcı email adresi
+     */
+    @NotBlank(message = "Email boş olamaz")
+    @Email(message = "Geçerli bir email adresi giriniz")
+    private String email;
+
+    /**
+     * Kullanıcı şifresi
+     */
+    @NotBlank(message = "Şifre boş olamaz")
+    private String password;
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/LoginRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.Email;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginRequest {
+
+    @Email(message = "Geçerli bir email adresi giriniz")
+    private String email;
+
+    private String password;
+
+    private String phoneNumber;
+
+    private String verificationCode;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/RefreshTokenRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/RefreshTokenRequest.java
@@ -1,0 +1,17 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequest {
+
+    @NotBlank(message = "Refresh token boş olamaz")
+    private String refreshToken;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/RegisterRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/RegisterRequest.java
@@ -1,0 +1,37 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterRequest {
+
+    @NotBlank(message = "Ad boş olamaz")
+    @Size(min = 2, max = 50, message = "Ad 2-50 karakter arasında olmalı")
+    private String firstName;
+
+    @NotBlank(message = "Soyad boş olamaz")
+    @Size(min = 2, max = 50, message = "Soyad 2-50 karakter arasında olmal��")
+    private String lastName;
+
+    @NotBlank(message = "Email boş olamaz")
+    @Email(message = "Geçerli bir email adresi giriniz")
+    private String email;
+
+    @NotBlank(message = "Şifre boş olamaz")
+    @Size(min = 8, max = 100, message = "Şifre en az 8 karakter olmalı")
+    private String password;
+
+    @Pattern(regexp = "^\\+?[0-9]{10,15}$", message = "Geçerli bir telefon numarası giriniz")
+    private String phoneNumber;
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/SendOtpRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/SendOtpRequest.java
@@ -1,0 +1,21 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SendOtpRequest {
+
+    /**
+     * OTP gönderilecek telefon numarası
+     */
+    @NotBlank(message = "Telefon numarası boş olamaz")
+    @Pattern(regexp = "^\\+?[0-9]{10,15}$", message = "Geçerli bir telefon numarası giriniz")
+    private String phoneNumber;
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/SmsLoginRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/SmsLoginRequest.java
@@ -1,0 +1,28 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SmsLoginRequest {
+
+    /**
+     * Kullanıcı telefon numarası
+     */
+    @NotBlank(message = "Telefon numarası boş olamaz")
+    @Pattern(regexp = "^\\+?[0-9]{10,15}$", message = "Geçerli bir telefon numarası giriniz")
+    private String phoneNumber;
+
+    /**
+     * SMS ile gelen doğrulama kodu (OTP)
+     * İlk istekte boş olabilir - OTP gönderilir
+     * İkinci istekte dolu olmalı - Doğrulama yapılır
+     */
+    private String verificationCode;
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/UserAuthRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/UserAuthRequest.java
@@ -1,0 +1,37 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAuthRequest {
+
+    @NotBlank(message = "Ad alanı boş olamaz")
+    @Size(min = 2, max = 50, message = "Ad 2-50 karakter arasında olmalıdır")
+    private String firstName;
+
+    @NotBlank(message = "Soyad alanı boş olamaz")
+    @Size(min = 2, max = 50, message = "Soyad 2-50 karakter arasında olmalıdır")
+    private String lastName;
+
+    @NotBlank(message = "Email alanı boş olamaz")
+    @Email(message = "Geçerli bir email adresi giriniz")
+    private String email;
+
+    @NotBlank(message = "Şifre alanı boş olamaz")
+    @Size(min = 8, max = 100, message = "Şifre en az 8 karakter olmalıdır")
+    private String password;
+
+    @Pattern(regexp = "^\\+?[0-9]{10,15}$", message = "Geçerli bir telefon numarası giriniz")
+    private String phoneNumber;
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/VerifyOtpRequest.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Request/VerifyOtpRequest.java
@@ -1,0 +1,28 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VerifyOtpRequest {
+
+    /**
+     * Kullanıcı telefon numarası
+     */
+    @NotBlank(message = "Telefon numarası boş olamaz")
+    @Pattern(regexp = "^\\+?[0-9]{10,15}$", message = "Geçerli bir telefon numarası giriniz")
+    private String phoneNumber;
+
+    /**
+     * SMS ile gelen doğrulama kodu (OTP)
+     */
+    @NotBlank(message = "Doğrulama kodu boş olamaz")
+    @Size(min = 6, max = 6, message = "Doğrulama kodu 6 haneli olmalıdır")
+    private String verificationCode;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/LoginResponse.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/LoginResponse.java
@@ -1,0 +1,27 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+    private Long expiresIn;
+    private Long userId;
+    private String email;
+    private String firstName;
+    private String lastName;
+    private String role;
+    private String phoneNumber;
+    private LocalDateTime loginTime;
+    private String status;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/OtpResponse.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/OtpResponse.java
@@ -1,0 +1,38 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OtpResponse {
+
+    /**
+     * İşlem durumu (OTP_SENT, ERROR)
+     */
+    private String status;
+
+    /**
+     * Kullanıcıya gösterilecek mesaj
+     */
+    private String message;
+
+    /**
+     * OTP gönderilen telefon numarası (maskelenmiş)
+     */
+    private String phoneNumber;
+
+    /**
+     * OTP'nin geçerlilik süresi (saniye)
+     */
+    private Integer expiresInSeconds;
+
+    /**
+     * İşlem zamanı
+     */
+    private LocalDateTime timestamp;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/RefreshTokenResponse.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/RefreshTokenResponse.java
@@ -1,0 +1,26 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+    private Long accessTokenExpiresIn;
+    private Long refreshTokenExpiresIn;
+    private LocalDateTime issuedAt;
+    private LocalDateTime accessTokenExpiresAt;
+    private LocalDateTime refreshTokenExpiresAt;
+    private String status;
+    private String message;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/RegisterResponse.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/RegisterResponse.java
@@ -1,0 +1,68 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegisterResponse {
+
+    /**
+     * Oluşturulan kullanıcının ID'si
+     */
+    private Long userId;
+
+    /**
+     * Kayıtlı email adresi
+     */
+    private String email;
+
+    /**
+     * Kayıtlı telefon numarası (varsa)
+     */
+    private String phoneNumber;
+
+    /**
+     * Kullanıcı adı
+     */
+    private String firstName;
+
+    /**
+     * Kullanıcı soyadı
+     */
+    private String lastName;
+
+    /**
+     * Kullanıcı rolü
+     */
+    private String role;
+
+    /**
+     * Hesap durumu (örn: "PENDING_VERIFICATION", "ACTIVE")
+     */
+    private String status;
+
+    /**
+     * Kayıt tarihi
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Başarı mesajı
+     */
+    private String message;
+
+    /**
+     * Doğrulama gerekli mi? (Email/SMS doğrulaması için)
+     */
+    private Boolean requiresVerification;
+
+    /**
+     * Doğrulama kodu gönderildi mi?
+     */
+    private Boolean verificationCodeSent;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/TokenResponse.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/TokenResponse.java
@@ -1,0 +1,24 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+    private Long accessTokenExpiresIn;
+    private Long refreshTokenExpiresIn;
+    private LocalDateTime issuedAt;
+    private LocalDateTime accessTokenExpiresAt;
+    private LocalDateTime refreshTokenExpiresAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/UserAuthResponse.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Dto/Response/UserAuthResponse.java
@@ -1,0 +1,25 @@
+package com.murat.orion.auth_service.AuthDomain.Dto.Response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAuthResponse {
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phoneNumber;
+    private String role;
+    private Boolean isActive;
+    private Boolean isEmailVerified;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastLoginAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/OtpCode.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/OtpCode.java
@@ -1,0 +1,80 @@
+package com.murat.orion.auth_service.AuthDomain.Entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "otp_codes", schema = "identity")
+public class OtpCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * OTP gönderilen telefon numarası
+     */
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    /**
+     * Oluşturulan OTP kodu (6 haneli)
+     */
+    @Column(nullable = false)
+    private String code;
+
+    /**
+     * OTP oluşturulma zamanı
+     */
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * OTP son geçerlilik zamanı
+     */
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    /**
+     * OTP kullanıldı mı?
+     */
+    @Column(nullable = false)
+    private Boolean isUsed = false;
+
+    /**
+     * Deneme sayısı (brute force koruması)
+     */
+    @Column(nullable = false)
+    private Integer attempts = 0;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    /**
+     * OTP'nin süresi dolmuş mu kontrol eder
+     */
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    /**
+     * OTP geçerli mi kontrol eder
+     */
+    public boolean isValid() {
+        return !isUsed && !isExpired() && attempts < 3;
+    }
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/Role.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/Role.java
@@ -1,0 +1,8 @@
+package com.murat.orion.auth_service.AuthDomain.Entity;
+
+public enum Role {
+    USER,
+    ADMIN,
+    MODERATOR
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/User.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/User.java
@@ -1,0 +1,101 @@
+package com.murat.orion.auth_service.AuthDomain.Entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "users", schema = "identity", indexes = {
+        @Index(name = "idx_user_email", columnList = "email"),
+        @Index(name = "idx_user_phone", columnList = "phone_number")
+})
+public class User implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(unique = true)
+    private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
+    @Column(nullable = false)
+    private Boolean isEmailVerified = false;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime lastLoginAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return isActive;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return isActive;
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/UserStatus.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Entity/UserStatus.java
@@ -1,0 +1,32 @@
+package com.murat.orion.auth_service.AuthDomain.Entity;
+
+/**
+ * Kullanıcı hesap durumları
+ */
+public enum UserStatus {
+    /**
+     * Aktif kullanıcı - Sisteme giriş yapabilir
+     */
+    ACTIVE,
+
+    /**
+     * Pasif kullanıcı - Geçici olarak devre dışı
+     */
+    INACTIVE,
+
+    /**
+     * Email/SMS doğrulaması bekliyor
+     */
+    PENDING_VERIFICATION,
+
+    /**
+     * Hesap kilitli - Güvenlik nedeniyle
+     */
+    LOCKED,
+
+    /**
+     * Hesap silinmiş (soft delete)
+     */
+    DELETED
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/AuthException.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/AuthException.java
@@ -1,0 +1,12 @@
+package com.murat.orion.auth_service.AuthDomain.Exception;
+
+public class AuthException extends RuntimeException {
+
+    public AuthException(String message) {
+        super(message);
+    }
+
+    public AuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/InvalidCredentialsException.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/InvalidCredentialsException.java
@@ -1,0 +1,12 @@
+package com.murat.orion.auth_service.AuthDomain.Exception;
+
+public class InvalidCredentialsException extends AuthException {
+
+    public InvalidCredentialsException() {
+        super("Invalid credentials provided");
+    }
+
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/InvalidOtpException.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/InvalidOtpException.java
@@ -1,0 +1,12 @@
+package com.murat.orion.auth_service.AuthDomain.Exception;
+
+public class InvalidOtpException extends AuthException {
+
+    public InvalidOtpException() {
+        super("Invalid or expired OTP");
+    }
+
+    public InvalidOtpException(String message) {
+        super(message);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/InvalidTokenException.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package com.murat.orion.auth_service.AuthDomain.Exception;
+
+import jakarta.security.auth.message.AuthException;
+
+public class InvalidTokenException extends AuthException {
+
+    public InvalidTokenException() {
+        super("Invalid or expired token");
+    }
+
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/TokenExpiredException.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/TokenExpiredException.java
@@ -1,0 +1,14 @@
+package com.murat.orion.auth_service.AuthDomain.Exception;
+
+import jakarta.security.auth.message.AuthException;
+
+public class TokenExpiredException extends AuthException {
+
+    public TokenExpiredException() {
+        super("Token has expired");
+    }
+
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/UserAlreadyExistsException.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/UserAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.murat.orion.auth_service.AuthDomain.Exception;
+
+public class UserAlreadyExistsException extends AuthException {
+
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+
+    public UserAlreadyExistsException(String email, String phoneNumber) {
+        super("User already exists with email: " + email + " or phone: " + phoneNumber);
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/UserNotFoundException.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.murat.orion.auth_service.AuthDomain.Exception;
+
+import jakarta.security.auth.message.AuthException;
+
+public class UserNotFoundException extends AuthException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+
+    public static UserNotFoundException withUsername(String username) {
+        return new UserNotFoundException("User not found with username: " + username);
+    }
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Loginİnterface.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Loginİnterface.java
@@ -1,0 +1,9 @@
+package com.murat.orion.auth_service.AuthDomain;
+
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.LoginResponse;
+
+public interface Loginİnterface<T> {
+    LoginResponse login(T loginRequest);
+
+    String getLoginType();
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Mapper/UserMapper.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Mapper/UserMapper.java
@@ -1,0 +1,39 @@
+package com.murat.orion.auth_service.AuthDomain.Mapper;
+
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.RegisterRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.RegisterResponse;
+import com.murat.orion.auth_service.AuthDomain.Entity.Role;
+import com.murat.orion.auth_service.AuthDomain.Entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public User toEntity(RegisterRequest request, String encodedPassword) {
+        return User.builder()
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .email(request.getEmail())
+                .password(encodedPassword)
+                .phoneNumber(request.getPhoneNumber())
+                .role(Role.USER)
+                .isActive(true)
+                .isEmailVerified(false)
+                .build();
+    }
+
+    public RegisterResponse toRegisterResponse(User user) {
+        return RegisterResponse.builder()
+                .userId(user.getId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .role(user.getRole().name())
+                .createdAt(user.getCreatedAt())
+                .status("SUCCESS")
+                .message("Kayıt başarıyla tamamlandı")
+                .build();
+    }
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Repository/OtpRepository.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Repository/OtpRepository.java
@@ -1,0 +1,22 @@
+package com.murat.orion.auth_service.AuthDomain.Repository;
+
+import com.murat.orion.auth_service.AuthDomain.Entity.OtpCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OtpRepository extends JpaRepository<OtpCode, Long> {
+
+    /**
+     * Telefon numarasına göre en son oluşturulan ve kullanılmamış OTP'yi bulur
+     */
+    Optional<OtpCode> findTopByPhoneNumberAndIsUsedFalseOrderByCreatedAtDesc(String phoneNumber);
+
+    /**
+     * Telefon numarasına göre tüm kullanılmamış OTP'leri siler
+     */
+    void deleteAllByPhoneNumberAndIsUsedFalse(String phoneNumber);
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Repository/UserRepository.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.murat.orion.auth_service.AuthDomain.Repository;
+
+import com.murat.orion.auth_service.AuthDomain.Entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByPhoneNumber(String phoneNumber);
+    boolean existsByEmail(String email);
+    boolean existsByPhoneNumber(String phoneNumber);
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/AuthService.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/AuthService.java
@@ -1,0 +1,87 @@
+package com.murat.orion.auth_service.AuthDomain.Service;
+
+import lombok.RequiredArgsConstructor;
+import com.murat.orion.auth_service.AuthDomain.Config.JwtService;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.RefreshTokenRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.RegisterRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.RefreshTokenResponse;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.RegisterResponse;
+import com.murat.orion.auth_service.AuthDomain.Entity.User;
+import com.murat.orion.auth_service.AuthDomain.Mapper.UserMapper;
+import com.murat.orion.auth_service.AuthDomain.Repository.UserRepository;
+import com.murat.orion.auth_service.Notification.Events.Auth.UserRegisteredEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final UserMapper userMapper;
+    private final JwtService jwtService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Transactional
+    public RegisterResponse register(RegisterRequest request) {
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new RuntimeException("Bu email adresi zaten kayıtlı");
+        }
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        User user = userMapper.toEntity(request, encodedPassword);
+
+        User savedUser = userRepository.save(user);
+
+        UserRegisteredEvent event = UserRegisteredEvent.builder()
+                .userId(savedUser.getId())
+                .email(savedUser.getEmail())
+                .phoneNumber(savedUser.getPhoneNumber())
+                .firstName(savedUser.getFirstName())
+                .lastName(savedUser.getLastName())
+                .registeredAt(LocalDateTime.now())
+                .build();
+        applicationEventPublisher.publishEvent(event);
+
+        return userMapper.toRegisterResponse(savedUser);
+    }
+
+    @Transactional(readOnly = true)
+    public RefreshTokenResponse refreshToken(RefreshTokenRequest request) {
+        String refreshToken = request.getRefreshToken();
+
+        if (!jwtService.validateToken(refreshToken)) {
+            throw new RuntimeException("Geçersiz veya süresi dolmuş refresh token");
+        }
+
+        String email = jwtService.extractUsername(refreshToken);
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("Kullanıcı bulunamadı"));
+
+        String newAccessToken = jwtService.generateToken(user);
+        String newRefreshToken = jwtService.generateRefreshToken(user);
+
+        LocalDateTime now = LocalDateTime.now();
+        long accessTokenExpiration = jwtService.getExpirationTime();
+        long refreshTokenExpiration = jwtService.getRefreshExpirationTime();
+
+        return RefreshTokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .tokenType("Bearer")
+                .accessTokenExpiresIn(accessTokenExpiration)
+                .refreshTokenExpiresIn(refreshTokenExpiration)
+                .issuedAt(now)
+                .accessTokenExpiresAt(now.plusSeconds(accessTokenExpiration / 1000))
+                .refreshTokenExpiresAt(now.plusSeconds(refreshTokenExpiration / 1000))
+                .status("SUCCESS")
+                .message("Token başarıyla yenilendi")
+                .build();
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/EmailLoginStrategy.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/EmailLoginStrategy.java
@@ -1,0 +1,78 @@
+package com.murat.orion.auth_service.AuthDomain.Service;
+
+import lombok.RequiredArgsConstructor;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.EmailLoginRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.LoginResponse;
+import com.murat.orion.auth_service.AuthDomain.Loginİnterface;
+import com.murat.orion.auth_service.AuthDomain.Repository.UserRepository;
+import com.murat.orion.auth_service.AuthDomain.Config.JwtService;
+import com.murat.orion.auth_service.Notification.Events.Auth.EmailLoginEvent;
+import com.murat.orion.auth_service.Notification.Events.Auth.LoginFailedEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class EmailLoginStrategy implements Loginİnterface<EmailLoginRequest> {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public LoginResponse login(EmailLoginRequest loginRequest) {
+        var user = userRepository.findByEmail(loginRequest.getEmail())
+                .orElseThrow(() -> {
+                    LoginFailedEvent failedEvent = LoginFailedEvent.builder()
+                            .email(loginRequest.getEmail())
+                            .reason("Kullanıcı bulunamadı")
+                            .failedAt(LocalDateTime.now())
+                            .build();
+                    applicationEventPublisher.publishEvent(failedEvent);
+                    return new RuntimeException("Kullanıcı bulunamadı");
+                });
+
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            LoginFailedEvent failedEvent = LoginFailedEvent.builder()
+                    .email(loginRequest.getEmail())
+                    .reason("Şifre yanlış")
+                    .failedAt(LocalDateTime.now())
+                    .build();
+            applicationEventPublisher.publishEvent(failedEvent);
+            throw new RuntimeException("Şifre yanlış");
+        }
+
+        String accessToken = jwtService.generateToken(user);
+        String refreshToken = jwtService.generateRefreshToken(user);
+
+        EmailLoginEvent event = EmailLoginEvent.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .loginAt(LocalDateTime.now())
+                .build();
+        applicationEventPublisher.publishEvent(event);
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .expiresIn(jwtService.getExpirationTime())
+                .userId(user.getId())
+                .email(user.getEmail())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .role(user.getRole().name())
+                .phoneNumber(user.getPhoneNumber())
+                .loginTime(LocalDateTime.now())
+                .status("SUCCESS")
+                .build();
+    }
+
+    @Override
+    public String getLoginType() {
+        return "EMAIL";
+    }
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/OtpService.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/OtpService.java
@@ -1,0 +1,98 @@
+package com.murat.orion.auth_service.AuthDomain.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.murat.orion.auth_service.AuthDomain.Entity.OtpCode;
+import com.murat.orion.auth_service.AuthDomain.Repository.OtpRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OtpService {
+
+    private final OtpRepository otpRepository;
+
+    private static final int OTP_EXPIRY_MINUTES = 5;
+
+    private static final int OTP_LENGTH = 6;
+
+
+    @Transactional
+    public String generateOtp(String phoneNumber) {
+        otpRepository.deleteAllByPhoneNumberAndIsUsedFalse(phoneNumber);
+
+        String otpCode = generateRandomOtp();
+
+        OtpCode otp = OtpCode.builder()
+                .phoneNumber(phoneNumber)
+                .code(otpCode)
+                .expiresAt(LocalDateTime.now().plusMinutes(OTP_EXPIRY_MINUTES))
+                .isUsed(false)
+                .attempts(0)
+                .build();
+
+        otpRepository.save(otp);
+
+        log.info("OTP oluşturuldu - Telefon: {}", maskPhoneNumber(phoneNumber));
+
+        return otpCode;
+    }
+
+
+    @Transactional
+    public boolean verifyOtp(String phoneNumber, String code) {
+        OtpCode otp = otpRepository.findTopByPhoneNumberAndIsUsedFalseOrderByCreatedAtDesc(phoneNumber)
+                .orElseThrow(() -> new RuntimeException("OTP bulunamadı"));
+
+        otp.setAttempts(otp.getAttempts() + 1);
+        otpRepository.save(otp);
+
+        if (!otp.isValid()) {
+            log.warn("OTP geçersiz veya süresi dolmuş - Telefon: {}", maskPhoneNumber(phoneNumber));
+            throw new RuntimeException("OTP geçersiz veya süresi dolmuş");
+        }
+
+        if (!otp.getCode().equals(code)) {
+            log.warn("Yanlış OTP girişi - Telefon: {}, Deneme: {}", maskPhoneNumber(phoneNumber), otp.getAttempts());
+
+            if (otp.getAttempts() >= 3) {
+                throw new RuntimeException("Çok fazla hatalı deneme. Lütfen yeni OTP isteyin.");
+            }
+
+            throw new RuntimeException("OTP kodu yanlış");
+        }
+
+        otp.setIsUsed(true);
+        otpRepository.save(otp);
+
+        log.info("OTP doğrulandı - Telefon: {}", maskPhoneNumber(phoneNumber));
+
+        return true;
+    }
+
+
+    private String generateRandomOtp() {
+        SecureRandom random = new SecureRandom();
+        StringBuilder otp = new StringBuilder();
+
+        for (int i = 0; i < OTP_LENGTH; i++) {
+            otp.append(random.nextInt(10));
+        }
+
+        return otp.toString();
+    }
+
+
+    private String maskPhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.length() < 4) {
+            return "***";
+        }
+        return phoneNumber.substring(0, 3) + "****" + phoneNumber.substring(phoneNumber.length() - 2);
+    }
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/SmsLoginStrategy.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/SmsLoginStrategy.java
@@ -1,0 +1,148 @@
+package com.murat.orion.auth_service.AuthDomain.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.murat.orion.auth_service.AuthDomain.Config.JwtService;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.SendOtpRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Request.VerifyOtpRequest;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.LoginResponse;
+import com.murat.orion.auth_service.AuthDomain.Dto.Response.OtpResponse;
+import com.murat.orion.auth_service.AuthDomain.Entity.User;
+import com.murat.orion.auth_service.AuthDomain.Repository.UserRepository;
+import com.murat.orion.auth_service.Notification.Events.Auth.LoginFailedEvent;
+import com.murat.orion.auth_service.Notification.Events.Auth.OtpSentEvent;
+import com.murat.orion.auth_service.Notification.Events.Auth.OtpVerifiedEvent;
+import com.murat.orion.auth_service.Notification.Events.Auth.SmsLoginEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class SmsLoginStrategy {
+
+    private final UserRepository userRepository;
+    private final OtpService otpService;
+    private final SmsService smsService;
+    private final JwtService jwtService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    private static final int OTP_EXPIRY_SECONDS = 300;
+
+
+    public OtpResponse sendOtp(SendOtpRequest request) {
+        String phoneNumber = request.getPhoneNumber();
+
+        User user = userRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> {
+                    LoginFailedEvent failedEvent = LoginFailedEvent.builder()
+                            .phoneNumber(phoneNumber)
+                            .reason("Bu telefon numarasına kayıtlı kullanıcı bulunamadı")
+                            .failedAt(LocalDateTime.now())
+                            .build();
+                    applicationEventPublisher.publishEvent(failedEvent);
+                    return new RuntimeException("Bu telefon numarasına kayıtlı kullanıcı bulunamadı");
+                });
+
+        String otpCode = otpService.generateOtp(phoneNumber);
+
+        smsService.sendOtp(phoneNumber, otpCode);
+
+        log.info("OTP gönderildi - Telefon: {}", maskPhoneNumber(phoneNumber));
+
+        OtpSentEvent otpEvent = OtpSentEvent.builder()
+                .userId(user.getId())
+                .phoneNumber(phoneNumber)
+                .otpType("SMS_LOGIN")
+                .sentAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusSeconds(OTP_EXPIRY_SECONDS))
+                .build();
+        applicationEventPublisher.publishEvent(otpEvent);
+
+        return OtpResponse.builder()
+                .status("OTP_SENT")
+                .message("Doğrulama kodu telefonunuza gönderildi")
+                .phoneNumber(maskPhoneNumber(phoneNumber))
+                .expiresInSeconds(OTP_EXPIRY_SECONDS)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+
+    public LoginResponse verifyOtpAndLogin(VerifyOtpRequest request) {
+        String phoneNumber = request.getPhoneNumber();
+        String verificationCode = request.getVerificationCode();
+
+        User user = userRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> {
+                    LoginFailedEvent failedEvent = LoginFailedEvent.builder()
+                            .phoneNumber(phoneNumber)
+                            .reason("Bu telefon numarasına kayıtlı kullanıcı bulunamadı")
+                            .failedAt(LocalDateTime.now())
+                            .build();
+                    applicationEventPublisher.publishEvent(failedEvent);
+                    return new RuntimeException("Bu telefon numarasına kayıtlı kullanıcı bulunamadı");
+                });
+
+        try {
+            otpService.verifyOtp(phoneNumber, verificationCode);
+        } catch (RuntimeException e) {
+            LoginFailedEvent failedEvent = LoginFailedEvent.builder()
+                    .phoneNumber(phoneNumber)
+                    .reason(e.getMessage())
+                    .failedAt(LocalDateTime.now())
+                    .build();
+            applicationEventPublisher.publishEvent(failedEvent);
+            throw e;
+        }
+
+        OtpVerifiedEvent otpVerifiedEvent = OtpVerifiedEvent.builder()
+                .userId(user.getId())
+                .phoneNumber(phoneNumber)
+                .otpType("SMS_LOGIN")
+                .verifiedAt(LocalDateTime.now())
+                .build();
+        applicationEventPublisher.publishEvent(otpVerifiedEvent);
+
+        String accessToken = jwtService.generateToken(user);
+        String refreshToken = jwtService.generateRefreshToken(user);
+
+        log.info("SMS login başarılı - Kullanıcı: {}", user.getEmail());
+
+        SmsLoginEvent smsLoginEvent = SmsLoginEvent.builder()
+                .userId(user.getId())
+                .phoneNumber(phoneNumber)
+                .loginAt(LocalDateTime.now())
+                .build();
+        applicationEventPublisher.publishEvent(smsLoginEvent);
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .expiresIn(jwtService.getExpirationTime())
+                .userId(user.getId())
+                .email(user.getEmail())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .role(user.getRole().name())
+                .phoneNumber(user.getPhoneNumber())
+                .loginTime(LocalDateTime.now())
+                .status("SUCCESS")
+                .build();
+    }
+
+    private String maskPhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.length() < 4) {
+            return "***";
+        }
+        return phoneNumber.substring(0, 3) + "****" + phoneNumber.substring(phoneNumber.length() - 2);
+    }
+
+    public String getLoginType() {
+        return "SMS";
+    }
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/SmsService.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/AuthDomain/Service/SmsService.java
@@ -1,0 +1,35 @@
+package com.murat.orion.auth_service.AuthDomain.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SmsService {
+
+
+
+    public void sendOtp(String phoneNumber, String otpCode) {
+
+
+        String message = String.format("Orion doğrulama kodunuz: %s. Bu kod 5 dakika geçerlidir.", otpCode);
+
+        log.info("SMS Gönderiliyor - Telefon: {}, Mesaj: {}", maskPhoneNumber(phoneNumber), message);
+
+
+
+        log.info("SMS başarıyla gönderildi - Telefon: {}", maskPhoneNumber(phoneNumber));
+    }
+
+
+    private String maskPhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.length() < 4) {
+            return "***";
+        }
+        return phoneNumber.substring(0, 3) + "****" + phoneNumber.substring(phoneNumber.length() - 2);
+    }
+}
+

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/EmailLoginEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/EmailLoginEvent.java
@@ -1,0 +1,22 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailLoginEvent {
+    private Long userId;
+    private String email;
+    private String phoneNumber;
+    private String subject;
+    private String ipAddress;
+    private String deviceInfo;
+    private LocalDateTime loginAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/LoginFailedEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/LoginFailedEvent.java
@@ -1,0 +1,22 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginFailedEvent {
+    private Long userId;
+    private String email;
+    private String phoneNumber;
+    private String subject;
+    private String ipAddress;
+    private String reason;
+    private LocalDateTime failedAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/OtpSentEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/OtpSentEvent.java
@@ -1,0 +1,22 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtpSentEvent {
+    private Long userId;
+    private String phoneNumber;
+    private String email;
+    private String subject;
+    private String otpType;
+    private LocalDateTime sentAt;
+    private LocalDateTime expiresAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/OtpVerifiedEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/OtpVerifiedEvent.java
@@ -1,0 +1,21 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtpVerifiedEvent {
+    private Long userId;
+    private String phoneNumber;
+    private String email;
+    private String subject;
+    private String otpType;
+    private LocalDateTime verifiedAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/PasswordChangedEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/PasswordChangedEvent.java
@@ -1,0 +1,20 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordChangedEvent {
+    private Long userId;
+    private String email;
+    private String phoneNumber;
+    private String subject;
+    private LocalDateTime changedAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/SmsLoginEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/SmsLoginEvent.java
@@ -1,0 +1,22 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsLoginEvent {
+    private Long userId;
+    private String email;
+    private String phoneNumber;
+    private String subject;
+    private String ipAddress;
+    private String deviceInfo;
+    private LocalDateTime loginAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/UserLoginEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/UserLoginEvent.java
@@ -1,0 +1,21 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+import lombok.NoArgsConstructor;
+import lombok.Data;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class UserLoginEvent {
+    private LocalDateTime loginAt;
+    private String deviceInfo;
+    private String ipAddress;
+    private String email;
+    private String phoneNumber;
+    private String subject;
+    private Long userId;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/UserLogoutEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/UserLogoutEvent.java
@@ -1,0 +1,20 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserLogoutEvent {
+    private Long userId;
+    private String email;
+    private String phoneNumber;
+    private String subject;
+    private LocalDateTime logoutAt;
+}

--- a/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/UserRegisteredEvent.java
+++ b/backend-microservices/auth-service/auth-service/src/main/java/com/murat/orion/auth_service/Notification/Events/Auth/UserRegisteredEvent.java
@@ -1,0 +1,22 @@
+package com.murat.orion.auth_service.Notification.Events.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegisteredEvent {
+    private Long userId;
+    private String email;
+    private String phoneNumber;
+    private String subject;
+    private String firstName;
+    private String lastName;
+    private LocalDateTime registeredAt;
+}


### PR DESCRIPTION
### Motivation
- Move the legacy monolith `AuthDomain` implementation into the new `auth-service` microservice so auth logic and DTO/entity models live inside the microservice package and can be evolved independently. 
- Preserve notification event models used by auth flows so event publishing in the auth paths remains functional after the migration.

### Description
- Copied the monolith `AuthDomain` sources into `backend-microservices/auth-service/auth-service` under the new package root `com.murat.orion.auth_service`, including controllers, services, configs, DTOs, entities, repositories, mappers and exceptions (e.g. `AuthController`, `AuthService`, `User`, `UserRepository`, `UserMapper`, `OtpService`, etc.).
- Added auth-related notification event classes into `Notification.Events.Auth` so auth event publishing continues to reference local event models (e.g. `UserRegisteredEvent`, `OtpSentEvent`, `LoginFailedEvent`).
- Introduced security and infra helpers such as `JwtService`, `JwtAuthenticationFilter`, `SecurityConfig`, and `OpenApiConfig`, and added log/debug output inside the authentication filter to aid early verification.
- Updated `auth-service` `pom.xml` to include required dependencies for the migrated code: `spring-boot-starter-validation`, JJWT libraries (`jjwt-api`, `jjwt-impl`, `jjwt-jackson`) and `springdoc-openapi-starter-webmvc-ui`.

### Testing
- Executed `mvn test` in `backend-microservices/auth-service/auth-service` which failed to run because Maven could not resolve the parent POM (attempt to fetch `spring-boot-starter-parent:3.5.11` from Maven Central returned `403 Forbidden`), so automated tests could not complete. 
- No unit/integration tests were executed successfully due to the parent POM resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69973a311aac8330b60214fbbddfa3bd)