### PR TITLE
feat: add auth event consumers to notification-service

### DIFF
--- a/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/Config/RabbitMQConfig.java
+++ b/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/Config/RabbitMQConfig.java
@@ -35,9 +35,15 @@ public class RabbitMQConfig {
     public MessageConverter messageConverter() {
         Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter();
         Map<String, Class<?>> idClassMapping = new HashMap<>();
-        idClassMapping.put("org.murat.accountservice.Event.AccountDebitedEvent", com.org.orion.notification_service.dto.AccountDebitedEvent.class);
+        idClassMapping.put("org.murat.accountservice.Event.AccountDebitedEvent",
+                com.org.orion.notification_service.dto.AccountDebitedEvent.class);
+        idClassMapping.put("com.murat.orion.auth_service.AuthDomain.Events.UserRegisteredEvent",
+                com.org.orion.notification_service.dto.UserRegisteredEvent.class);
+        idClassMapping.put("com.murat.orion.auth_service.AuthDomain.Events.OtpSentEvent",
+                com.org.orion.notification_service.dto.OtpSentEvent.class);
         DefaultClassMapper classMapper = new DefaultClassMapper();
         classMapper.setIdClassMapping(idClassMapping);
+        classMapper.setTrustedPackages("*");
         converter.setClassMapper(classMapper);
         return converter;
     }

--- a/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/Dto/OtpSentEvent.java
+++ b/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/Dto/OtpSentEvent.java
@@ -1,0 +1,21 @@
+package com.org.orion.notification_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtpSentEvent implements Serializable {
+    private Long userId;
+    private String phoneNumber;
+    private String email;
+    private String otpCode;
+    private String otpType;
+    private LocalDateTime sentAt;
+    private LocalDateTime expiresAt;
+}

--- a/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/Dto/UserRegisteredEvent.java
+++ b/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/Dto/UserRegisteredEvent.java
@@ -1,0 +1,20 @@
+package com.org.orion.notification_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegisteredEvent implements Serializable {
+    private Long userId;
+    private String email;
+    private String phoneNumber;
+    private String firstName;
+    private String lastName;
+    private LocalDateTime registeredAt;
+}

--- a/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/consumer/NotificationConsumer.java
+++ b/backend-microservices/notification-service/notification-service/src/main/java/com/org/orion/notification_service/consumer/NotificationConsumer.java
@@ -1,17 +1,41 @@
 package com.org.orion.notification_service.consumer;
 
 import com.org.orion.notification_service.dto.AccountDebitedEvent;
+import com.org.orion.notification_service.dto.OtpSentEvent;
+import com.org.orion.notification_service.dto.UserRegisteredEvent;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RabbitListener(queues = "notification.queue")
 public class NotificationConsumer {
-    @RabbitListener(queues = "notification.queue")
-    public void consumeAccountDebitedEvent(AccountDebitedEvent event) {
-        log.info(" MESAJ ALINDI: UserID: {}, Tutar: {}, Mesaj: {}",
+
+    @RabbitHandler
+    public void handleAccountDebitedEvent(AccountDebitedEvent event) {
+        log.info("MESAJ ALINDI: UserID: {}, Tutar: {}, Mesaj: {}",
                 event.getUserId(), event.getAmount(), event.getMessage());
         log.info("SMS Gönderiliyor... [BAŞARILI]");
+    }
+
+    @RabbitHandler
+    public void handleUserRegisteredEvent(UserRegisteredEvent event) {
+        log.info("Yeni kullanıcı kaydı alındı - UserID: {}, Email: {}, Ad: {} {}",
+                event.getUserId(), event.getEmail(), event.getFirstName(), event.getLastName());
+        log.info("Hoş geldiniz e-postası gönderiliyor: {} [BAŞARILI]", event.getEmail());
+    }
+
+    @RabbitHandler
+    public void handleOtpSentEvent(OtpSentEvent event) {
+        log.info("OTP bildirimi alındı - UserID: {}, Telefon: {}, Tip: {}",
+                event.getUserId(), event.getPhoneNumber(), event.getOtpType());
+        log.info("OTP SMS bildirimi gönderiliyor: {} [BAŞARILI]", event.getPhoneNumber());
+    }
+
+    @RabbitHandler(isDefault = true)
+    public void handleDefault(Object event) {
+        log.warn("Bilinmeyen mesaj tipi alındı: {}", event);
     }
 }

--- a/backend-microservices/notification-service/notification-service/src/main/resources/application.yaml
+++ b/backend-microservices/notification-service/notification-service/src/main/resources/application.yaml
@@ -6,6 +6,23 @@ spring:
     name: notification-service
   config:
     import: "${SPRING_CONFIG_IMPORT:optional:configserver:http://localhost:8888/}"
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+    virtual-host: ${RABBITMQ_VHOST:/}
+    connection-timeout: 10000
+    listener:
+      simple:
+        acknowledge-mode: auto
+        prefetch: 1
+        retry:
+          enabled: true
+          initial-interval: 1000
+          max-interval: 10000
+          max-attempts: 3
+          multiplier: 2.0
 
 eureka:
   client:


### PR DESCRIPTION
- Add UserRegisteredEvent and OtpSentEvent DTOs for deserialization
- Update RabbitMQConfig class mapper with auth-service event type mappings
- Refactor NotificationConsumer to use @RabbitListener on class level with @RabbitHandler methods for type-based message routing
- Add RabbitMQ connection configuration to application.yaml
- Add default handler for unknown message types

https://claude.ai/code/session_01WopbyY6hxMJRkGiVjPbLNx